### PR TITLE
ci(propeller-v2): fix composables-v2 build order in publish workflow

### DIFF
--- a/.github/workflows/publish-v2-packages.yaml
+++ b/.github/workflows/publish-v2-packages.yaml
@@ -95,6 +95,14 @@ jobs:
           ' CHANGELOG.md > "$RUNNER_TEMP/RELEASE_BODY.md"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
+      # composables-v2 imports @propeller-commerce/propeller-api-v2, resolved via
+      # node_modules → api-client-v2/lib (its built types). Each matrix job is a
+      # fresh runner, so that sibling's lib/ isn't present from the api-client-v2
+      # job — build the in-repo dependency first so tsc can resolve it.
+      - name: Build in-repo dependency
+        if: steps.changelog.outputs.skip != 'true' && matrix.dir == 'composables-v2'
+        run: npm run build --workspace=@propeller-commerce/propeller-api-v2
+
       - name: Build
         if: steps.changelog.outputs.skip != 'true'
         working-directory: packages/${{ matrix.dir }}


### PR DESCRIPTION
Follow-up to #11. The first dry-run of the publish workflow caught a real CI-only failure: the `composables-v2` build job failed with 25 `TS2307` errors — it couldn't resolve `@propeller-commerce/propeller-api-v2`.

Cause: each matrix job runs on a fresh runner, so `api-client-v2/lib/` (the built types `composables-v2` imports) wasn't present when the `composables-v2` job ran. Locally it passed only because that `lib/` already existed.

Fix: build the in-repo dependency (`api-client-v2`) first in the `composables-v2` job.

Reproduced locally by deleting `api-client-v2/lib` (composables build → 25 TS2307), then confirmed building the dependency first makes it exit 0.