### PR TITLE
ci(propeller-v2): make GitHub Release step non-fatal

### DIFF
--- a/.github/workflows/publish-v2-packages.yaml
+++ b/.github/workflows/publish-v2-packages.yaml
@@ -133,8 +133,13 @@ jobs:
           fi
           npm publish --access public
 
+      # Non-fatal: the repo has an active "tag create protection" ruleset that
+      # blocks the Actions token from creating the release tag ("creations being
+      # restricted"). npm publish is the artifact that matters, so a blocked
+      # Release must never fail the job (mirrors GitLab allow_failure: true).
       - name: Create GitHub Release
         if: steps.changelog.outputs.skip != 'true' && inputs.dry_run != true
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
The first real publish run revealed that the repo's active **"tag create protection"** ruleset blocks the Actions token from creating release tags (`HTTP 422: Cannot create ref due to creations being restricted`).

Outcome of that run:
- ✅ `@propeller-commerce/propeller-api-v2@0.1.0` published to npm successfully
- ❌ its GitHub Release step then failed on the tag rule, failing the job
- ❌ that cancelled the serial `composables-v2` job, so it never published

Fix: mark the **Create GitHub Release** step `continue-on-error: true` so a blocked tag never fails the job — npm publish is the artifact that matters. Mirrors the `allow_failure: true` the GitLab release jobs use.

After merge, re-running the workflow will publish `composables-v2@0.1.0` (api-client-v2 is already up and will be skipped by the idempotent guard).